### PR TITLE
fix: update version in package.json to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-viewer",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "description": "React library for viewing AWS Step Functions workflows in the browser",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This pull request updates the version of the `asl-viewer` package in its `package.json` file. The version has been incremented from `1.0.2` to `1.0.5`.